### PR TITLE
fix: reduce homepage getStaticProps revalidate from 1s to 1200s (20 min)

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -268,7 +268,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
       topLikeReports,
       ...translations,
     },
-    revalidate: 1,
+    revalidate: 1200,
   };
 }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -268,6 +268,9 @@ export async function getStaticProps(context: GetStaticPropsContext) {
       topLikeReports,
       ...translations,
     },
+    // Revalidate every 20 minutes to balance freshness with performance.
+    // The topLikeReports query is expensive with nested includes; health checks
+    // every 5s were causing high CPU usage with the previous 1s revalidate.
     revalidate: 1200,
   };
 }


### PR DESCRIPTION
## Problem

The homepage (`/src/pages/index.tsx`) had `revalidate: 1`, causing `getStaticProps` to re-run on **every HTTP request**. Since Coolify's health check hits `https://growagram.com/` every 5 seconds, this triggers a heavy Prisma query (`topLikeReports` with deeply nested includes) ~12 times per minute, keeping CPU at **20-30%** on a near-idle service.

## Fix

Changed `revalidate` from `1` (1 second) to `1200` (20 minutes).

The `topLikeReports` data only displays 4 top report cards on the landing page — it doesn't need real-time freshness. 20 minutes is more than sufficient.

## Impact on deploy

Once merged, Coolify will auto-deploy the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased static page caching interval so pages are rebuilt less frequently, leading to fewer background rebuilds and improved runtime performance and stability for end-users.
  * Clarified inline comments to improve maintainability for future updates.
  * No public API or exported interface changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->